### PR TITLE
Enhanced typings for SalesOrder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trieb.work/zoho-ts",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "description": "Node Library for Zoho Inventory, Invoice and Zoho Books",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trieb.work/zoho-ts",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "Node Library for Zoho Inventory, Invoice and Zoho Books",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/types/salesOrder.ts
+++ b/src/types/salesOrder.ts
@@ -100,9 +100,10 @@ export type CreateSalesOrder =
  */
 type CustomFieldsDirectAPIResponse = { [key: string]: unknown };
 
-export type SalesOrderStatus = "void" | "confirmed" | "closed";
-export type SalesOrderShippedStatus = "shipped" | "fulfilled" | "pending" | "";
-export type SalesOrderInvoicedStatus = "invoiced" | "not_invoiced" | "";
+export type SalesOrderStatus = "draft" | "void" | "onhold" | "confirmed" | "closed";
+export type SalesOrderShippedStatus = "shipped" | "partially_shipped" | "fulfilled" | "pending" | "";
+export type SalesOrderInvoicedStatus = "invoiced" | "not_invoiced" | "partially_invoiced" | "";
+export type SalesOrderPaidStatus = "paid" | "not_paid" | "partially_paid" | "";
 
 /**
  * A sales order is a financial document that confirms an impending sale. It
@@ -463,6 +464,8 @@ export type SalesOrder = {
     shipping_charge_tax_percentage: number | "";
 
     invoiced_status: SalesOrderInvoicedStatus;
+
+    paid_status: SalesOrderPaidStatus;
 
     shipped_status: SalesOrderShippedStatus;
 


### PR DESCRIPTION
What was done:
- Added typing for `paid_status` missing in the SalesOrder interface. Was 'picked' in ListSalesOrder though.
- Enhanced status type literals with 'paritially_' prefixes. 
- Added `onhold`, `draft` order statuses.