### PR TITLE
pass apiFlavour from config to avoid taking default "inventory"

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -220,6 +220,7 @@ export class ZohoApiClient {
             },
             baseUrl: config.baseUrl,
             dc: dataCenter,
+            apiFlavour: config.apiFlavour
         });
     }
 


### PR DESCRIPTION
Hi Team,

While I was playing around, I saw the module is not able to send API requests to Books/Invoices due to the fact that whatever apiFlavour we provide, it seems to take "inventory" by default. the problem lies with the fact that it was not being passed on to api client. just adding that fixed the issue